### PR TITLE
Sync our repo with upstream

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 1
 
       - name: build image
-        run: docker build -t digitalocean/doks-debug:latest .
+        run: docker build --platform linux/amd64 -t digitalocean/doks-debug:latest .
 
       - name: Log into container registry
         run: echo "${{ secrets.DockerHubToken }}" | docker login --username ${DOCKER_USER} --password-stdin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,5 @@
 name: release
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GHCRTOKEN }}
-
 on:
   push:
     branches:
@@ -20,6 +17,9 @@ jobs:
 
       - name: build image
         run: docker build --platform linux/amd64 -t ghcr.io/digitalocean-packages/doks-debug:latest .
+
+      - name: log into container registry
+        run: echo "${{ secrets.GHCRTOKEN }}" | docker login --username "${{ secrets.GHCRUSER }}" --password-stdin
 
       - name: push image
         run: docker push ghcr.io/digitalocean-packages/doks-debug:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: release
 
 env:
-  DOCKER_USER: ${{ secrets.DockerHubUser }}
+  GITHUB_TOKEN: ${{ secrets.GHCRTOKEN }}
 
 on:
   push:
@@ -14,15 +14,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579  # v2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:
           fetch-depth: 1
 
       - name: build image
-        run: docker build --platform linux/amd64 -t digitalocean/doks-debug:latest .
-
-      - name: Log into container registry
-        run: echo "${{ secrets.DockerHubToken }}" | docker login --username ${DOCKER_USER} --password-stdin
+        run: docker build --platform linux/amd64 -t ghcr.io/digitalocean-packages/doks-debug:latest .
 
       - name: push image
-        run: docker push digitalocean/doks-debug:latest
+        run: docker push ghcr.io/digitalocean-packages/doks-debug:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         run: docker build --platform linux/amd64 -t ghcr.io/digitalocean-packages/doks-debug:latest .
 
       - name: log into container registry
-        run: echo "${{ secrets.GHCRTOKEN }}" | docker login --username "${{ secrets.GHCRUSER }}" --password-stdin
+        run: echo "${{ secrets.GHCRTOKEN }}" | docker login ghcr.io --username "${{ secrets.GHCRUSER }}" --password-stdin
 
       - name: push image
         run: docker push ghcr.io/digitalocean-packages/doks-debug:latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 1
 
       - name: build image
-        run: docker build -t doks-debug .
+        run: docker build --platform linux/amd64 -t doks-debug .
 
       - name: smoke test
         run: docker run --rm doks-debug sleep 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ WORKDIR /root
 
 # use same dpkg path-exclude settings that come by default with ubuntu:focal
 # image that we previously used
-RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' > /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-include=/usr/share/doc/*/copyright' > /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' > /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' >> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/copyright' ≥> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' ≥> /etc/dpkg/dpkg.cfg.d/excludes
 
 RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # match doks-debug version with DOKS worker node image version for kernel
 # tooling compatibility reasons
-FROM debian:10-slim
+FROM debian:12-slim
 
 WORKDIR /root
 
@@ -10,8 +10,6 @@ RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' > /etc/dpkg/dpkg.cf
 RUN echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/excludes
 RUN echo 'path-include=/usr/share/doc/*/copyright' > /etc/dpkg/dpkg.cfg.d/excludes
 RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' > /etc/dpkg/dpkg.cfg.d/excludes
-
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
 
 RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \
@@ -42,12 +40,12 @@ RUN apt-get update -qq && \
                        dsniff \
                        mtr-tiny \
                        conntrack \
-                       llvm-8 llvm-8-tools \
+                       llvm-13 llvm-13-tools \
                        bpftool
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     apt-get update -qq && \
-    apt-get install -y docker-ce
+    apt-get install -y docker
 
 CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,4 @@ RUN apt-get update -qq && \
                        llvm-13 llvm-13-tools \
                        bpftool
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update -qq && \
-    apt-get install -y docker
-
 CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update -qq && \
                        tcpdump \
                        traceroute \
                        iputils-ping \
+                       iptables \
                        net-tools \
                        ncat \
                        iproute2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,17 @@
 # tooling compatibility reasons
 FROM debian:12-slim
 
+# Specify the version of crictl to install
+ARG CRICTL_VERSION="v1.31.1"
+
 WORKDIR /root
 
 # use same dpkg path-exclude settings that come by default with ubuntu:focal
 # image that we previously used
 RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' >> /etc/dpkg/dpkg.cfg.d/excludes
 RUN echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-include=/usr/share/doc/*/copyright' ≥> /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' ≥> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/copyright' >> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' >> /etc/dpkg/dpkg.cfg.d/excludes
 
 RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \
@@ -42,6 +45,17 @@ RUN apt-get update -qq && \
                        mtr-tiny \
                        conntrack \
                        llvm-13 llvm-13-tools \
+                       wget \
                        bpftool
+
+# Install crictl
+RUN wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz && \
+    tar zxvf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz -C /usr/local/bin && \
+    rm -f crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+
+# Specify the default image endpoint for crictl
+RUN echo 'runtime-endpoint: unix:///run/containerd/containerd.sock' >> /etc/crictl.yaml
+RUN echo 'image-endpoint: unix:///run/containerd/containerd.sock' >> /etc/crictl.yaml
+RUN echo 'timeout: 2' >> /etc/crictl.yaml
 
 CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -qq && \
                        jq \
                        dnsutils \
                        tcpdump \
+                       termshark \
                        traceroute \
                        iputils-ping \
                        iptables \
@@ -38,6 +39,7 @@ RUN apt-get update -qq && \
                        ncat \
                        iproute2 \
                        strace \
+                       lsof \
                        telnet \
                        openssl \
                        psmisc \
@@ -46,6 +48,7 @@ RUN apt-get update -qq && \
                        conntrack \
                        llvm-13 llvm-13-tools \
                        wget \
+                       watch \
                        bpftool
 
 # Install crictl

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This DaemonSet manifest will:
  1. Ensure a pod with our Docker image is running indefinitely on every node.
  2. Use `hostPID`, `hostIPC`, and `hostNetwork`.
  3. Mount the entire host filesystem to `/host` in the containers.
+ 4. Mount the `containerd` socket at `/run/containerd/containerd.sock` from the host into the container.
 
 In order to make use of these workloads, you can exec into a pod of choice by name:
 
@@ -49,7 +50,9 @@ Once you're in, you have access to the set of tools listed in the `Dockerfile`. 
  - [`dstat`](http://dag.wiee.rs/home-made/dstat/) - is a versatile replacement for vmstat, iostat, netstat and ifstat. Dstat overcomes some of their limitations and adds some extra features, more counters and flexibility. Dstat is handy for monitoring systems during performance tuning tests, benchmarks or troubleshooting.
  - [`htop`](https://hisham.hm/htop/) - is interactive process viewer for Unix systems.
  - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.
-
+ - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.
+ - [`wget`](https://www.gnu.org/software/wget/) - for retrieving files using HTTP, HTTPS, FTP and FTPS.
+ - [`crictl`](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md) - A CLI for CRI endpoints. Configured to use `/run/containerd/containerd.sock` as a default endpoint. 
 # Tips and Tricks
 
 ## chroot + systemctl

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This DaemonSet manifest will:
  1. Ensure a pod with our Docker image is running indefinitely on every node.
  2. Use `hostPID`, `hostIPC`, and `hostNetwork`.
  3. Mount the entire host filesystem to `/host` in the containers.
- 4. Mount `/var/run/docker.sock` from the host.
 
 In order to make use of these workloads, you can exec into a pod of choice by name:
 
@@ -47,7 +46,6 @@ Once you're in, you have access to the set of tools listed in the `Dockerfile`. 
  - [`netcat`](https://linux.die.net/man/1/nc) - is a multi-tool for interacting with TCP and UDP; it can open TCP connections, send UDP packets, listen on arbitrary TCP and UDP ports, do port scanning, and deal with both IPv4 and IPv6.
  - [`iproute2`](https://wiki.linuxfoundation.org/networking/iproute2) - is a collection of utilities for controlling TCP / IP networking and traffic control in Linux.
  - [`strace`](https://github.com/strace/strace) - is a diagnostic, debugging and instructional userspace utility with a traditional command-line interface for Linux. It is used to monitor and tamper with interactions between processes and the Linux kernel, which include system calls, signal deliveries, and changes of process state.
- - [`docker`](https://docs.docker.com/engine/reference/commandline/cli/) - is the CLI tool used for interacting with Docker containers on the system.
  - [`dstat`](http://dag.wiee.rs/home-made/dstat/) - is a versatile replacement for vmstat, iostat, netstat and ifstat. Dstat overcomes some of their limitations and adds some extra features, more counters and flexibility. Dstat is handy for monitoring systems during performance tuning tests, benchmarks or troubleshooting.
  - [`htop`](https://hisham.hm/htop/) - is interactive process viewer for Unix systems.
  - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Once you're in, you have access to the set of tools listed in the `Dockerfile`. 
  - [`dstat`](http://dag.wiee.rs/home-made/dstat/) - is a versatile replacement for vmstat, iostat, netstat and ifstat. Dstat overcomes some of their limitations and adds some extra features, more counters and flexibility. Dstat is handy for monitoring systems during performance tuning tests, benchmarks or troubleshooting.
  - [`htop`](https://hisham.hm/htop/) - is interactive process viewer for Unix systems.
  - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.
- - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.
  - [`wget`](https://www.gnu.org/software/wget/) - for retrieving files using HTTP, HTTPS, FTP and FTPS.
  - [`crictl`](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md) - A CLI for CRI endpoints. Configured to use `/run/containerd/containerd.sock` as a default endpoint. 
 # Tips and Tricks

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       hostIPC: true
       hostNetwork: true

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -39,11 +39,17 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
+          - name: containerd
+            mountPath: /run/containerd/containerd.sock
       terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:
             path: /
+        - name: containerd
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket
   updateStrategy:
     rollingUpdate:
       maxSurge: 0

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -39,6 +39,7 @@ spec:
             mountPath: /host
           - name: docker
             mountPath: /var/run/docker.sock
+      terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
         name: doks-debug
       annotations:
         clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       hostPID: true
       hostIPC: true

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -39,17 +39,11 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
-          - name: docker
-            mountPath: /var/run/docker.sock
       terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:
             path: /
-        - name: docker
-          hostPath:
-            path: /var/run/docker.sock
-            type: Socket
   updateStrategy:
     rollingUpdate:
       maxSurge: 0

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       - name: doks-debug
         securityContext:
           privileged: true
-        image: digitalocean/doks-debug:latest
+        image: ghcr.io/digitalocean-packages/doks-debug:latest
         command: [ "sleep", "infinity" ]
         resources:
           requests:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -40,6 +40,7 @@ spec:
             mountPath: /host
           - name: docker
             mountPath: /var/run/docker.sock
+      terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -40,17 +40,11 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
-          - name: docker
-            mountPath: /var/run/docker.sock
       terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:
             path: /
-        - name: docker
-          hostPath:
-            path: /var/run/docker.sock
-            type: Socket
   strategy:
     rollingUpdate:
       maxSurge: 0

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -40,11 +40,17 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
+          - name: containerd
+            mountPath: /run/containerd/containerd.sock
       terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:
             path: /
+        - name: containerd
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket
   strategy:
     rollingUpdate:
       maxSurge: 0

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       - name: doks-debug
         securityContext:
           privileged: true
-        image: digitalocean/doks-debug:latest
+        image: ghcr.io/digitalocean-packages/doks-debug:latest
         command: [ "sleep", "infinity" ]
         resources:
           requests:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       hostIPC: true
       hostNetwork: true

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         name: doks-debug
       annotations:
         clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       hostPID: true
       hostIPC: true


### PR DESCRIPTION
We were some commits behind upstream, this PR syncs the upstream with our own.

This pull request includes several updates to improve compatibility and functionality by transitioning from Docker to containerd, updating the base Docker image, and adding new tools. The most important changes include modifications to the Dockerfiles, workflow files, and Kubernetes manifests.

### Transition from Docker to containerd:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R15): Changed the base image from `debian:10-slim` to `debian:12-slim`, added installation steps for `crictl`, and updated the default image endpoint configuration. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R15) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L45-R59)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20): Updated instructions to reflect the switch from Docker to containerd, including mounting the `containerd` socket and adding `crictl` to the list of tools. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R54)
* `k8s/daemonset.yaml` and `k8s/deployment.yaml`: Replaced Docker socket mounts with containerd socket mounts and added annotations for safe eviction and DNS policy. [[1]](diffhunk://#diff-5a4444071374b1df7a43cf0e29b1ce77d1d3b4f699a825baa821f292ed42dcc8R18-R20) [[2]](diffhunk://#diff-5a4444071374b1df7a43cf0e29b1ce77d1d3b4f699a825baa821f292ed42dcc8L40-R51) [[3]](diffhunk://#diff-4bbade0e44f036b32fc63c2e5838f57268ec49ff70dfce1afb9e12849515dd38R19-R21) [[4]](diffhunk://#diff-4bbade0e44f036b32fc63c2e5838f57268ec49ff70dfce1afb9e12849515dd38L41-R52)

### Workflow updates:

* `.github/workflows/release.yaml` and `.github/workflows/test.yaml`: Added the `--platform linux/amd64` flag to the `docker build` commands to ensure compatibility with the target platform. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL22-R22) [[2]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L16-R16)

### Tooling updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R36): Added `iptables`, `wget`, and upgraded `llvm` from version 8 to 13. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R36) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L45-R59)
